### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "geoip-lite": "^1.1.6",
     "jsonschema": "^1.0.3",
     "mongodb": "^2.0.48",
-    "node-uuid": "^1.4.7",
     "redis": "^2.4.2",
+    "uuid": "^3.0.0",
     "ws": "^0.8.0"
   },
   "devDependencies": {

--- a/services/matchmaking.js
+++ b/services/matchmaking.js
@@ -4,7 +4,7 @@
 	Mapping to one 1st-party platform session ID as required
 */
 
-const uuid = require('node-uuid')
+const uuid = require('uuid')
 const jsonschema = require('jsonschema')
 
 // if we can't resolve an IP, dump it at the north pole to match with other people we can't classify

--- a/services/state.js
+++ b/services/state.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const os = require('os')
-const uuid = require('node-uuid')
+const uuid = require('uuid')
 
 module.exports = function*(loader)
 {

--- a/services/telemetry.js
+++ b/services/telemetry.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const uuid = require('node-uuid')
+const uuid = require('uuid')
 
 module.exports = function*(loader)
 {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -2,7 +2,7 @@
 
 const WebSocket = require('ws')
 const MetagameServer = require('../metagame')
-const uuid = require('node-uuid')
+const uuid = require('uuid')
 const assert = require('assert')
 const mongodb = require('mongodb')
 const util = require('util')


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.